### PR TITLE
Fix multiple query loops

### DIFF
--- a/includes/classes/QueryModifications.php
+++ b/includes/classes/QueryModifications.php
@@ -13,6 +13,13 @@ namespace CuratedQueryLoop;
 class QueryModifications extends Module {
 
 	/**
+	 * The block with its attributes before it gets rendered.
+	 *
+	 * @var array
+	 */
+	public $parsed_block;
+
+	/**
 	 * Checks whether the Module should run within the current context.
 	 *
 	 * @return bool
@@ -33,39 +40,67 @@ class QueryModifications extends Module {
 	/**
 	 * Modifies the query loop to include the post picker posts.
 	 *
-	 * @param $block_content string The block content.
-	 * @param $block array The block object.
-	 *
-	 * @return void
+	 * @param  string $block_content The block content.
+	 * @param  array  $block         The block object.
+	 * @return string
 	 */
 	public function modify_query_loop_query( $block_content, $block ) {
-		if ( 'core/query' === $block['blockName'] ) {
 
-			$ids = isset( $block['attrs']['selectedPosts'] )
-				? $this->get_ids_from_content_picker( $block['attrs']['selectedPosts'] )
-				: [];
-
-			if ( $ids !== [] ) {
-				add_filter(
-					'query_loop_block_query_vars',
-					function ( $query_args ) use ( $ids ) {
-						$query_args['post__in'] = $ids;
-						$query_args['orderby'] = 'post__in';
-
-						return $query_args;
-					}
-				);
-			}
+		if ( ! isset( $block['attrs']['namespace'] ) ) {
+			return $block_content;
 		}
+
+		if ( 'curated-query-loop' !== $block['attrs']['namespace'] ) {
+			return $block_content;
+		}
+
+		$this->parsed_block = $block;
+
+		add_filter( 'query_loop_block_query_vars', [ $this, 'get_query_by_attributes_once' ] );
 
 		return $block_content;
 	}
 
-	private function get_ids_from_content_picker( $posts ) {
-		$ids = [];
-		foreach ( $posts as $post ) {
-			$ids[] = $post['id'];
+	/**
+	 * Remove the query block filter and parse the custom query.
+	 *
+	 * @param  array $query_args Array containing parameters for `WP_Query`.
+	 * @return array
+	 */
+	public function get_query_by_attributes_once( $query_args ) {
+		remove_filter( 'query_loop_block_query_vars', [ $this, 'get_query_by_attributes_once' ] );
+		return $this->get_query_by_attributes( $query_args, $this->parsed_block );
+	}
+
+	/**
+	 * Returns a custom query based on block attributes.
+	 *
+	 * @param  array $query_args Array containing parameters for `WP_Query`.
+	 * @param  array $block      The block being rendered.
+	 * @return array
+	 */
+	public function get_query_by_attributes( $query_args, $block ) {
+
+		if ( ! isset( $block['attrs']['namespace'] ) ) {
+			return $query_args;
 		}
-		return $ids;
+
+		if ( 'curated-query-loop' !== $block['attrs']['namespace'] ) {
+			return $query_args;
+		}
+
+		$post_ids = [];
+		if ( isset( $block['attrs']['selectedPosts'] ) ) {
+			$post_ids = wp_list_pluck( $block['attrs']['selectedPosts'], 'id' );
+		}
+
+		if ( empty( $post_ids ) ) {
+			return $query_args;
+		}
+
+		$query_args['post__in'] = $post_ids;
+		$query_args['orderby']  = 'post__in';
+
+		return $query_args;
 	}
 }


### PR DESCRIPTION
Hi @psorensen 

This pull request resolves an issue encountered when multiple query loops exist on the same page.

When the curated query loop block is placed first with a selection of curated posts, followed by a standard query loop, the latter is affected by the query arguments of the curated block, particularly with the `post__in` arg. This issue happens only in the frontend, while both blocks function as intended in the editor.